### PR TITLE
Universal MPR support

### DIFF
--- a/examples/Example2_AdvancedReadings/Example2_AdvancedReadings.ino
+++ b/examples/Example2_AdvancedReadings/Example2_AdvancedReadings.ino
@@ -1,0 +1,79 @@
+/*
+  Basic test of the MPR MicroPressure Sensor with transfer function other than default 'A'
+  By: Urs Utzinger
+  Date: November 2024
+*/
+
+#include <Wire.h>
+#include <SparkFun_MicroPressure.h>
+
+// Serial
+#define BAUD_RATE          500000     // Up to 2,000,000 on ESP32, however more than 500 kBaud might be unreliable
+
+// I2C speed
+#define I2C_SPEED           400000     // 400,000, 100,000 50,000
+#define I2C_STRETCH             50     //  50, 200 ms, typical is 230 micro seconds
+#ifndef SDA
+  #define SDA 3
+#endif
+#ifndef SCL
+  #define SCL 4
+#endif
+TwoWire myWire = TwoWire(0);           // Create a TwoWire instance
+
+// Example for MPRLS0300GY pressure sensor used to measure blood pressure in mmHg
+// 300mmHg = 5.80104 PSI is max pressure
+#define EOC_PIN -1
+#define RST_PIN -1
+#define I2C_ADDRESS 0x18
+#define MIN_PSI 0
+#define MAX_PSI 5.80104
+#define TRANSFER_FUNCTION 'B'
+
+SparkFun_MicroPressure mpr(EOC_PIN, RST_PIN, MIN_PSI, MAX_PSI, TRANSFER_FUNCTION);
+uint32_t lastTime;
+
+void setup() {
+  Serial.begin(115200);
+
+  myWire.begin(SDA, SCL);
+  myWire.setClock(I2C_SPEED);
+  myWire.setTimeOut(I2C_STRETCH);
+
+  if(!mpr.begin(I2C_ADDRESS, myWire))
+  {
+    Serial.println("Cannot connect to MicroPressure sensor.");
+    while(1);
+  }
+  
+  // Optional: set the measured zero pressure value
+  // mpr.setZero(419430); 
+
+  // Optional: for manual calibration with a water column e.g. in a plastic tube
+  // (you need to select appropriate length of water column to not damage the sensor)
+  //   1 mmHg ≈ 13.5951 mmH₂O
+  //   1 mmH₂O ≈ 0.00142233 PSI
+  // Example calculation:
+  //   minCounts =  419430; measured raw counts with 0 mm Water Column
+  //   2meterH2OCounts = 3000000; measured raw counts with a 2 meter Water Column
+  //   deltaCounts = 2meterH2OCounts - minCounts
+  //   calculatedPSI = 2000mm * 0.00142233 PSI/mm 
+  //   deltaPSI = calculatedPSI - 0 PSI
+  //   calFactor = deltaPSI / deltaCounts
+  // mpr.setCalFac(5.80104/3355444);
+
+  lastTime = micros();
+}
+
+void loop() {
+  uint32_t currentTime= micros();
+  if(currentTime - lastTime >= 2*6250) { // 6250 micros = 160Hz is maximum rate
+    lastTime = currentTime;
+    Serial.print(mpr.readPressure(TORR),3);
+    Serial.print(" mmHg ");
+    Serial.print(mpr.readPressure(RAW),3);
+    Serial.println(" counts");
+  } else {
+    delay(1);
+  }
+}

--- a/src/SparkFun_MicroPressure.cpp
+++ b/src/SparkFun_MicroPressure.cpp
@@ -14,13 +14,58 @@
    - (Optional) rst_pin, Reset pin for MPR sensor. Default: -1 (skip)
    - minimumPSI, minimum range value of the sensor (in PSI). Default: 0
    - maximumPSI, maximum range value of the sensor (in pSI). Default: 25
+
+   The maximum and minimum PSI are listed in the datasheet of the sensor.
+   They are in units of PSI, kPa, bar, or mmHg depending on the sensor type.
+   For this software to work properly you need to convert them to PSI.
 */
-SparkFun_MicroPressure::SparkFun_MicroPressure(int8_t eoc_pin, int8_t rst_pin, uint8_t minimumPSI, uint8_t maximumPSI)
+SparkFun_MicroPressure::SparkFun_MicroPressure(int8_t eoc_pin, int8_t rst_pin, float minimumPSI, float maximumPSI, char transfer_function)
 {
   _eoc = eoc_pin;
   _rst = rst_pin;
   _minPsi = minimumPSI;
   _maxPsi = maximumPSI;
+  _transfer_function = transfer_function;
+
+  // MPR Sensors can have 3 different types of transfer functions
+  // In the data sheet they are called A, B, C
+  //   each function has two calibration points; one axis is sensor counts and the other is pressure
+  //   counts are given below, min and max pressure is stated in the datasheet for each of the sensor types
+  //   min and max corresponds to the counts below
+  //
+  // maximum possible counts is 2^24 = 16777216
+  // A 
+  // 10% * 16777216   =  1677722 = min Counts
+  // 90% * 16777216   = 15099494 = max Counts
+  // B
+  //  2.5% * 16777216 =  419430
+  // 22.5% * 16777216 = 3774874
+  // C
+  // 20% * 16777216   =  3355443
+  // 80% * 16777216   = 13421773
+
+  switch (_transfer_function)
+  {
+    case 'A':
+      _minCounts =  1677722;
+      _maxCounts = 15099494;
+      break;
+    case 'B':
+      _minCounts =  419430;
+      _maxCounts = 3774874;
+      break;
+    case 'C':
+      _minCounts =  3355443;
+      _maxCounts = 13421773;
+      break;
+    default:
+      _minCounts =  1677722;
+      _maxCounts = 15099494;
+      break;
+  }
+  _deltaCounts = _maxCounts - _minCounts;
+  _deltaPsi = _maxPsi - _minPsi;
+  _calFactor = _deltaPsi / float(_deltaCounts) ;
 }
 
 /* Initialize hardware
@@ -63,18 +108,44 @@ uint8_t SparkFun_MicroPressure::readStatus(void)
 {
   _i2cPort->requestFrom(_address,1);
   return _i2cPort->read();
+} 
+
+/* Provide runtime zeroing of the sensor
+   zero, is the value in counts at minimum pressure
+   zero is automatically calculated based on the transfer function
+   however these values can be improved by measuring the zero pressure reading
+*/
+void SparkFun_MicroPressure::setZero(uint32_t zero)
+{
+  _minCounts = zero;
+  _deltaCounts = _maxCounts - _minCounts;
+  _calFactor = _deltaPsi / float(_deltaCounts) ;
+}
+
+/* Provide runtime calibration option for he sensor
+   calFac, is the calibration factor
+   calFac is automatically calculated based on the transfer function and max and min pressure
+   However these values can be improved by measuring the sensor at a known pressure,
+   for example by measuring the pressure in a water column at a known height or depth
+*/
+void SparkFun_MicroPressure::setCalFac(float calFac)
+{
+  _calFactor = calFac;
+  _deltaPsi = _calFactor * float(_deltaCounts);
+  _maxPsi = _minPsi + _deltaPsi;
 }
 
 /* Read the Pressure Sensor Reading
  - (optional) Pressure_Units, can return various pressure units. Default: PSI
    Pressure Units available:
-     - PSI: Pounds per Square Inch
+   - PSI: Pounds per Square Inch
 	 - PA: Pascals
 	 - KPA: Kilopascals
-	 - TORR
+	 - TORR: mm Mercury
 	 - INHG: Inch of Mercury
 	 - ATM: Atmospheres
-	 - BAR
+	 - BAR: Bars
+   - RAW: returns the raw 24-bit pressure reading
 */
 float SparkFun_MicroPressure::readPressure(Pressure_Units units)
 {
@@ -120,17 +191,21 @@ float SparkFun_MicroPressure::readPressure(Pressure_Units units)
     if(i != 2) reading = reading<<8;
   }
 
-  //convert from 24-bit to float psi value
-  float pressure;
-  pressure = (reading - OUTPUT_MIN) * (_maxPsi - _minPsi);
-  pressure = (pressure / (OUTPUT_MAX - OUTPUT_MIN)) + _minPsi;
+  if (units == RAW){
+    return float(reading);
+  } 
+  else {
+    //convert from counts to pressure
+    float pressure;
+    pressure = ( ( float(int32_t(reading) - int32_t(_minCounts)) ) * _calFactor )  + _minPsi;
 
-  if(units == PSI)       return pressure; //PSI
-  else if(units == PA)   return pressure*6894.7573; //Pa (Pascal)
-  else if(units == KPA)  return pressure*6.89476;   //kPa (kilopascal)
-  else if(units == TORR) return pressure*51.7149;   //torr (mmHg)
-  else if(units == INHG) return pressure*2.03602;   //inHg (inch of mercury)
-  else if(units == ATM)  return pressure*0.06805;   //atm (atmosphere)
-  else if(units == BAR)  return pressure*0.06895;   //bar
-  else                   return pressure; //PSI
+    if(units == PSI)       return pressure;           //PSI (pounds per square inch)
+    else if(units == PA)   return pressure*6894.7573; //Pa (Pascal, Newton per square meter)
+    else if(units == KPA)  return pressure*6.89476;   //kPa (kilopascal)
+    else if(units == TORR) return pressure*51.7149;   //torr (mmHg)
+    else if(units == INHG) return pressure*2.03602;   //inHg (inch of mercury)
+    else if(units == ATM)  return pressure*0.06805;   //atm (atmosphere, 1atm = 1.01325bar)
+    else if(units == BAR)  return pressure*0.06895;   //bar (1bar = 100,000Pa)
+    else                   return pressure;           //PSI
+  }
 }

--- a/src/SparkFun_MicroPressure.h
+++ b/src/SparkFun_MicroPressure.h
@@ -14,9 +14,6 @@
 #define INTEGRITY_FLAG  0x04
 #define MATH_SAT_FLAG   0x01
 
-#define OUTPUT_MAX 0xE66666
-#define OUTPUT_MIN 0x19999A
-
 enum Pressure_Units {
   PSI,
   PA,
@@ -24,22 +21,26 @@ enum Pressure_Units {
   TORR,
   INHG,
   ATM,
-  BAR
+  BAR,
+  RAW
 };
 
 class SparkFun_MicroPressure
 {
   public:
-    SparkFun_MicroPressure(int8_t eoc_pin=-1, int8_t rst_pin=-1, uint8_t minimumPSI=MINIMUM_PSI, uint8_t maximumPSI=MAXIMUM_PSI);
+    SparkFun_MicroPressure(int8_t eoc_pin=-1, int8_t rst_pin=-1, float minimumPSI=MINIMUM_PSI, float maximumPSI=MAXIMUM_PSI, char transfer_function='A');
     bool begin(uint8_t deviceAddress = DEFAULT_ADDRESS, TwoWire &wirePort = Wire);
     uint8_t readStatus(void);
     float readPressure(Pressure_Units units=PSI);
+    void setZero(uint32_t zero);
+    void setCalFac(float calFac);
     
   private:
     int8_t _address;
-	int8_t _eoc, _rst;
-	
-    uint8_t _minPsi, _maxPsi;
+	  int8_t _eoc, _rst;
+    float _minPsi, _maxPsi, _deltaPsi, _calFactor;
+    uint32_t _zero, _maxCounts, _minCounts, _deltaCounts;
+    char _transfer_function;
     
     TwoWire *_i2cPort;
 };


### PR DESCRIPTION
This is an update for the library to enable all 3 types of transfer functions of this series of pressures sensors.

The library now provides ability to zero the sensor at run time. The library now provides option to update the calibration. Those settings are defined by the transfer function, however measuring the calibration will improve performance.

The library now provides option to report RAW sensor counts, which is needed for calibration.

The math to convert sensor counts to pressure has been reworked and will now report negative numbers instead of overflowing to the max scale of uint32_t.

An example program using different sensor types is provided as second example.

Code written for previous version of the library will continue running.