### PR TITLE
Rename PA to MPR_PA in Pressure_Units enum

### DIFF
--- a/src/SparkFun_MicroPressure.h
+++ b/src/SparkFun_MicroPressure.h
@@ -19,7 +19,7 @@
 
 enum Pressure_Units {
   PSI,
-  PA,
+  MPR_PA,
   KPA,
   TORR,
   INHG,


### PR DESCRIPTION
There appears to be a conflict with certain AVR PortA ("PA") designations; altered pascal units to have a prefix to fix